### PR TITLE
fix: detect symlinked skill folders in list/sync commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openskills",
-  "version": "1.0.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openskills",
-      "version": "1.0.0",
+      "version": "1.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inquirer/prompts": "^7.9.0",
@@ -24,7 +24,7 @@
         "vitest": "^4.0.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.6.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {


### PR DESCRIPTION
These commands were missing symlinked folders because entry.isDirectory() returns false for symlinks. Now we use statSync() to follow symlinks and properly detect directory symlinks in ~/.claude/skills and ~/.agent/skills.