### PR TITLE
fix: Use path.sep for cross-platform path validation

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync, existsSync, mkdirSync, rmSync, cpSync, statSync } from 'fs';
-import { join, basename, resolve } from 'path';
+import { join, basename, resolve, sep } from 'path';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
 import chalk from 'chalk';
@@ -194,7 +194,7 @@ async function installSingleLocalSkill(
   // Security: ensure target path stays within target directory
   const resolvedTargetPath = resolve(targetPath);
   const resolvedTargetDir = resolve(targetDir);
-  if (!resolvedTargetPath.startsWith(resolvedTargetDir + '/')) {
+  if (!resolvedTargetPath.startsWith(resolvedTargetDir + sep)) {
     console.error(chalk.red(`Security error: Installation path outside target directory`));
     process.exit(1);
   }
@@ -244,7 +244,7 @@ async function installSpecificSkill(
   // Security: ensure target path stays within target directory
   const resolvedTargetPath = resolve(targetPath);
   const resolvedTargetDir = resolve(targetDir);
-  if (!resolvedTargetPath.startsWith(resolvedTargetDir + '/')) {
+  if (!resolvedTargetPath.startsWith(resolvedTargetDir + sep)) {
     console.error(chalk.red(`Security error: Installation path outside target directory`));
     process.exit(1);
   }
@@ -370,7 +370,7 @@ async function installFromRepo(
     // Security: ensure target path stays within target directory
     const resolvedTargetPath = resolve(info.targetPath);
     const resolvedTargetDir = resolve(targetDir);
-    if (!resolvedTargetPath.startsWith(resolvedTargetDir + '/')) {
+    if (!resolvedTargetPath.startsWith(resolvedTargetDir + sep)) {
       console.error(chalk.red(`Security error: Installation path outside target directory`));
       continue;
     }


### PR DESCRIPTION
# fix: Use path.sep for cross-platform path validation

This PR fixes a security check failure on Windows when installing skills.

The previous implementation used a hardcoded forward slash (`/`) to validate that the installation path is within the target directory. On Windows, `path.resolve` returns paths with backslashes (`\`), causing the `startsWith` check to fail and triggering the error: `Security error: Installation path outside target directory`.

## Changes

- Replaced hardcoded `'/'` with `path.sep` in [src/commands/install.ts](cci:7://file:///e:/AndroidStudioProjects/openskills/src/commands/install.ts:0:0-0:0) to ensure compatibility with the OS-specific path separator.

## Related Issue

#17

## Verification

1. Run `openskills install <skill>` on a Windows machine.
2. Verify that the installation proceeds without the security error.