### PR TITLE
Update README with installation command details for non Claude Code u…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```bash
 npm i -g openskills
-openskills install anthropics/skills # installs to locally by default
+openskills install anthropics/skills # installs locally by default
 openskills sync
 ```
 


### PR DESCRIPTION
**Issue:** 
People new to the Claude Code and Skills ecosystem may assume that skill installation is global by default because the CLI install is usually global. 
When they navigate to project directory and try to update Agents.md they will be prompted with this error message: 

> No skills installed. Install skills first:
>   openskills install anthropics/skills --project

...which is not a helpful message for anyone that is not using Claude Code.

**Proposed solution:**
Clarify in the example that skill installation is local by default