### PR TITLE
feat: add Nix flake for declarative builds and development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 *.log
 .openskills-temp/
 .claude/
+result
+.direnv/

--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ OpenSkills replicates Claude Code's skills system with **100% compatibility**:
 npm i -g openskills
 ```
 
+<details>
+<summary>Using Nix</summary>
+
+```bash
+nix profile install github:numman-ali/openskills
+
+# or run directly
+nix run github:numman-ali/openskills -- --help
+```
+
+</details>
+
 ### 2. Install Skills
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1766736597,
+        "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f560ccec6b1116b22e6ed15f4c510997d99d5852",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,93 @@
+{
+  description = "Universal skills loader for AI coding agents";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          packageJson = pkgs.lib.importJSON ./package.json;
+          nodejs = pkgs.nodejs_22;
+        in
+        {
+          default = pkgs.buildNpmPackage (finalAttrs: {
+            pname = "openskills";
+            version = packageJson.version;
+            src = ./.;
+
+            # Update this hash when package-lock.json changes:
+            # nix build 2>&1 | grep 'got:' | awk '{print $2}'
+            npmDepsHash = "sha256-unmxbQHOHsKF0mGCPP1eSe2H1cm7nMsTwObkF9MN2yQ=";
+
+            inherit nodejs;
+
+            buildPhase = ''
+              runHook preBuild
+              npm run build
+              runHook postBuild
+            '';
+
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p $out/lib/openskills
+              cp -r dist $out/lib/openskills/
+              cp -r node_modules $out/lib/openskills/
+              cp package.json $out/lib/openskills/
+
+              mkdir -p $out/bin
+              makeWrapper ${nodejs}/bin/node $out/bin/openskills \
+                --add-flags "$out/lib/openskills/dist/cli.js"
+
+              runHook postInstall
+            '';
+
+            nativeBuildInputs = [ pkgs.makeWrapper ];
+
+            meta = with pkgs.lib; {
+              description = packageJson.description;
+              homepage = "https://github.com/numman-ali/openskills";
+              license = licenses.asl20;
+              mainProgram = "openskills";
+            };
+          });
+        }
+      );
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          nodejs = pkgs.nodejs_22;
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = [
+              nodejs
+              pkgs.git
+            ];
+
+            shellHook = ''
+              echo "OpenSkills development shell"
+              echo "Node.js: $(node --version)"
+              echo "npm: $(npm --version)"
+            '';
+          };
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/openskills";
+        };
+      });
+    };
+}


### PR DESCRIPTION
## Summary

- Add Nix flake support for declarative builds and development environments
- Enables `nix build`, `nix run`, and `nix develop` for the project

## Changes

- `flake.nix`: Nix flake with `buildNpmPackage`, devShell, and app outputs
- `flake.lock`: Locked to nixos-25.11 stable
- `.gitignore`: Added `result` and `.direnv/` entries
- `README.md`: Added Nix installation option in collapsible section

## Usage

```bash
# Install globally
nix profile install github:numman-ali/openskills

# Run directly without installing
nix run github:numman-ali/openskills -- --help

# Development shell
nix develop github:numman-ali/openskills
```