### PR TITLE
Fix: Windows path separator and dynamic version reading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1817,9 +1817,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import { Command } from 'commander';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { listSkills } from './commands/list.js';
 import { installSkill } from './commands/install.js';
 import { readSkill } from './commands/read.js';
@@ -8,12 +11,19 @@ import { removeSkill } from './commands/remove.js';
 import { manageSkills } from './commands/manage.js';
 import { syncAgentsMd } from './commands/sync.js';
 
+// Get version from package.json
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJsonPath = join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+const version = packageJson.version;
+
 const program = new Command();
 
 program
   .name('openskills')
   .description('Universal skills loader for AI coding agents')
-  .version('1.2.1')
+  .version(version)
   .showHelpAfterError(false)
   .exitOverride((err) => {
     // Handle all commander errors gracefully (no stack traces)

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync, existsSync, mkdirSync, rmSync, cpSync, statSync } from 'fs';
-import { join, basename, resolve } from 'path';
+import { join, basename, resolve, relative, sep } from 'path';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
 import chalk from 'chalk';
@@ -194,9 +194,10 @@ async function installSingleLocalSkill(
   // Security: ensure target path stays within target directory
   const resolvedTargetPath = resolve(targetPath);
   const resolvedTargetDir = resolve(targetDir);
-  if (!resolvedTargetPath.startsWith(resolvedTargetDir + '/')) {
-    console.error(chalk.red(`Security error: Installation path outside target directory`));
-    process.exit(1);
+  const relativePath = relative(resolvedTargetDir, resolvedTargetPath);
+  if (relativePath.startsWith('..') || relative(resolvedTargetDir, resolvedTargetPath).includes('..')) {
+	console.error(chalk.red(`Security error: Installation path outside target directory`));
+	process.exit(1);
   }
 
   cpSync(skillDir, targetPath, { recursive: true, dereference: true });
@@ -244,9 +245,10 @@ async function installSpecificSkill(
   // Security: ensure target path stays within target directory
   const resolvedTargetPath = resolve(targetPath);
   const resolvedTargetDir = resolve(targetDir);
-  if (!resolvedTargetPath.startsWith(resolvedTargetDir + '/')) {
-    console.error(chalk.red(`Security error: Installation path outside target directory`));
-    process.exit(1);
+  const relativePath = relative(resolvedTargetDir, resolvedTargetPath);
+  if (relativePath.startsWith('..')) {
+   console.error(chalk.red(`Security error: Installation path outside target directory`));
+   process.exit(1);
   }
   cpSync(skillDir, targetPath, { recursive: true, dereference: true });
 
@@ -370,9 +372,10 @@ async function installFromRepo(
     // Security: ensure target path stays within target directory
     const resolvedTargetPath = resolve(info.targetPath);
     const resolvedTargetDir = resolve(targetDir);
-    if (!resolvedTargetPath.startsWith(resolvedTargetDir + '/')) {
-      console.error(chalk.red(`Security error: Installation path outside target directory`));
-      continue;
+    const relativePath = relative(resolvedTargetDir, resolvedTargetPath);
+    if (relativePath.startsWith('..')) {
+     console.error(chalk.red(`Security error: Installation path outside target directory`));
+     continue;
     }
     cpSync(info.skillDir, info.targetPath, { recursive: true, dereference: true });
 

--- a/tests/commands/install.test.ts
+++ b/tests/commands/install.test.ts
@@ -138,10 +138,11 @@ describe('install.ts helper functions', () => {
   describe('path traversal security', () => {
     // Test the security check logic
     const isPathSafe = (targetPath: string, targetDir: string): boolean => {
-      const resolvedTargetPath = resolve(targetPath);
-      const resolvedTargetDir = resolve(targetDir);
-      return resolvedTargetPath.startsWith(resolvedTargetDir + '/');
-    };
+	  const resolvedTargetPath = resolve(targetPath);
+	  const resolvedTargetDir = resolve(targetDir);
+	  const relativePath = require('path').relative(resolvedTargetDir, resolvedTargetPath);
+	  return !relativePath.startsWith('..');
+	};
 
     it('should allow normal skill paths within target directory', () => {
       expect(isPathSafe('/home/user/.claude/skills/my-skill', '/home/user/.claude/skills')).toBe(true);


### PR DESCRIPTION
The security check was using hardcoded '/' separator which fails on Windows.
Changed to use path.relative() for cross-platform path validation.

Also changed hardcoded version '1.2.1' to dynamically read from package.json
to ensure CLI always reports the correct version.

Note: Issue #20 reported both the Windows installation failure and the 
hardcoded version problem.

Closes #17
Closes #20
Closes #28
Closes #29
Closes #34

<!--
┌─────┬─────┬─────┬─────┬─────┐
│ 102 │ 113 │  86 │  93 │  95 │
├─────┼─────┼─────┼─────┼─────┤
│  88 │  90 │  97 │ 104 │ 110 │
├─────┼─────┼─────┼─────┼─────┤
│  99 │ 101 │ 112 │  85 │  92 │
├─────┼─────┼─────┼─────┼─────┤
│ 109 │  87 │  94 │  96 │ 103 │
├─────┼─────┼─────┼─────┼─────┤
│  91 │  98 │ 100 │ 111 │  89 │
└─────┴─────┴─────┴─────┴─────┘
-->