### PR TITLE
fix: Use path.sep for Windows compatibility in path validation

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync, existsSync, mkdirSync, rmSync, cpSync, statSync } from 'fs';
-import { join, basename, resolve } from 'path';
+import { join, basename, resolve, sep } from 'path';
 import { homedir } from 'os';
 import { execSync } from 'child_process';
 import chalk from 'chalk';
@@ -194,7 +194,7 @@ async function installSingleLocalSkill(
   // Security: ensure target path stays within target directory
   const resolvedTargetPath = resolve(targetPath);
   const resolvedTargetDir = resolve(targetDir);
-  if (!resolvedTargetPath.startsWith(resolvedTargetDir + '/')) {
+  if (!resolvedTargetPath.startsWith(resolvedTargetDir + sep)) {
     console.error(chalk.red(`Security error: Installation path outside target directory`));
     process.exit(1);
   }
@@ -244,7 +244,7 @@ async function installSpecificSkill(
   // Security: ensure target path stays within target directory
   const resolvedTargetPath = resolve(targetPath);
   const resolvedTargetDir = resolve(targetDir);
-  if (!resolvedTargetPath.startsWith(resolvedTargetDir + '/')) {
+  if (!resolvedTargetPath.startsWith(resolvedTargetDir + sep)) {
     console.error(chalk.red(`Security error: Installation path outside target directory`));
     process.exit(1);
   }
@@ -370,7 +370,7 @@ async function installFromRepo(
     // Security: ensure target path stays within target directory
     const resolvedTargetPath = resolve(info.targetPath);
     const resolvedTargetDir = resolve(targetDir);
-    if (!resolvedTargetPath.startsWith(resolvedTargetDir + '/')) {
+    if (!resolvedTargetPath.startsWith(resolvedTargetDir + sep)) {
       console.error(chalk.red(`Security error: Installation path outside target directory`));
       continue;
     }


### PR DESCRIPTION
## Problem

Path security validation fails on Windows with error:
> "Security error: Installation path outside target directory"

This **blocks ALL skill installations on Windows** and affects multiple users (Issues #34, #28, #29, #17, #20).

### User Impact
- ❌ Windows 10/11 users cannot install any skills
- ❌ Affects both project (`--project`) and global (`--global`) installations
- ❌ All 17 skills from `anthropics/skills` fail to install
- ✅ Unix/Linux/macOS users not affected

## Root Cause

The security check used hardcoded forward slash `/` for path comparison:
```typescript
if (!resolvedTargetPath.startsWith(resolvedTargetDir + '/')) {
  console.error('Security error: Installation path outside target directory');
  process.exit(1);
}
```

**Why this fails on Windows:**
- Windows uses backslash `\` as path separator
- `path.resolve()` returns Windows paths like `C:\Users\test\.claude\skills`
- Check becomes: `C:\Users\test\.claude\skills\my-skill`.startsWith(`C:\Users\test\.claude\skills/`)
- Mixed separators (`\` vs `/`) cause the check to fail incorrectly

## Solution

Use Node.js built-in `path.sep` constant for cross-platform compatibility:

```typescript
import { sep } from 'path';

if (!resolvedTargetPath.startsWith(resolvedTargetDir + sep)) {
  console.error('Security error: Installation path outside target directory');
  process.exit(1);
}
```

**How this works:**
- Unix/Linux/macOS: `sep` = `/`
- Windows: `sep` = `\`
- Paths are compared using the correct separator for each platform

## Changes

### Modified Files
1. **`src/commands/install.ts`**
   - Import `sep` from `path` module
   - Replace 3 occurrences of hardcoded `'/'` with `sep`

2. **`tests/commands/install.test.ts`**
   - Import `sep` from `path` module
   - Update existing path security tests to use `sep`
   - Add 2 new Windows-specific test cases
   - Use `resolve()` for proper cross-platform path normalization

### Test Coverage
✅ Added Windows path validation tests:
- Test Windows drive letters (`C:/Users/test/.claude/skills`)
- Test Windows path traversal prevention
- All existing security tests still pass

## Testing

Ran full test suite:
```
Test Files: 6 passed (6)
Tests: 90 passed (90)
Duration: 1.41s
```

## Impact

✅ **Unblocks all Windows users**
✅ Maintains security on all platforms
✅ No breaking changes for Unix/Linux/macOS users
✅ Backward compatible

## Related Issues

Closes #34
Closes #28
Closes #29
Closes #17
Closes #20

## Checklist

- [x] Code follows project style
- [x] Tests pass locally
- [x] New tests added for Windows compatibility
- [x] No breaking changes
- [x] Fixes critical bug affecting Windows users

## Additional Notes

This is a **critical bug fix** that unblocks all Windows users. The change is minimal, focused, and thoroughly tested. It maintains the same security guarantees on all platforms while fixing the Windows-specific issue.