### PR TITLE
chore: add .agent folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ skills/
 .tmp/
 .venv-skill/
 reports/
+.agent


### PR DESCRIPTION
## Description
This PR adds the `.agent` folder to the `.gitignore` file to prevent agent-specific files from being committed to the repository.

## Changes Made
- Added `.agent` entry to `.gitignore` to exclude the folder from version control

## Motivation and Context
The `.agent` folder is intended for agent-specific configurations and temporary files that should not be shared across users. 