### PR TITLE
fix: Windows path support across CLI commands

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -27,7 +27,9 @@ function isLocalPath(source: string): boolean {
     source.startsWith('/') ||
     source.startsWith('./') ||
     source.startsWith('../') ||
-    source.startsWith('~/')
+    source.startsWith('~/') ||
+    source.startsWith('~\\') ||                   // Windows home directory with backslash
+    /^[a-zA-Z]:[/\\]/.test(source)               // Windows drive (C:/ or C:\)
   );
 }
 
@@ -56,10 +58,11 @@ function getRepoName(repoUrl: string): string | null {
 }
 
 /**
- * Expand ~ to home directory
+ * Expand ~ to home directory and normalize path
  */
 function expandPath(source: string): string {
-  if (source.startsWith('~/')) {
+  // Support both Unix (~/) and Windows (~\) tilde notation
+  if (source.startsWith('~/') || source.startsWith('~\\')) {
     return join(homedir(), source.slice(2));
   }
   return resolve(source);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
-import { dirname, basename } from 'path';
+import { dirname, basename, resolve, join } from 'path';
+import { homedir } from 'os';
 import chalk from 'chalk';
 import { checkbox } from '@inquirer/prompts';
 import { ExitPromptError } from '@inquirer/core';
@@ -13,10 +14,22 @@ export interface SyncOptions {
 }
 
 /**
+ * Expand ~ to home directory and resolve path
+ */
+function expandPath(path: string): string {
+  // Support both Unix (~/) and Windows (~\) tilde notation
+  if (path.startsWith('~/') || path.startsWith('~\\')) {
+    return join(homedir(), path.slice(2));
+  }
+  return resolve(path);
+}
+
+/**
  * Sync installed skills to a markdown file
  */
 export async function syncAgentsMd(options: SyncOptions = {}): Promise<void> {
-  const outputPath = options.output || 'AGENTS.md';
+  const rawOutputPath = options.output || 'AGENTS.md';
+  const outputPath = expandPath(rawOutputPath);
   const outputName = basename(outputPath);
 
   // Validate output file is markdown


### PR DESCRIPTION
## Summary

This PR fixes Windows path handling issues reported in #64 and #65, and adds support for both forward and backward slashes in path inputs.

## Changes

### Fixed Issues
- **Closes #64**: The `sync` command's `-o` parameter now correctly expands tilde (`~`) to the user's home directory on Windows
- **Closes #65**: The `install` command now recognizes Windows absolute paths (`C:/`, `C:\) tilde notation across all commands
- Windows drive letters are now recognized in both forward slash (`C:/`) and backslash (`C:\
  - Windows drive letters: `/^[a-zA-Z]:[/\]/`
- Updated `expandPath()` to support both Unix and Windows tilde notation

## Testing

- ✅ Build passes successfully
- ✅ All path formats are now correctly recognized as local paths
- ✅ Tilde expansion works on both Unix and Windows

## Before/After

### Before
```bash
# Windows - tilde not expanded
npx openskills sync -o ~/.config/opencode/AGENTS.md
# Created: <CurrentPath>/~/.config/opencode/AGENTS.md ❌

# Windows - absolute path not recognized
npx openskills install C:/Users/jayvi/.agent/skills/gh-cli
# Error: Tries to clone from GitHub ❌
```

### After
```bash
# Windows - tilde properly expanded
npx openskills sync -o ~/.config/opencode/AGENTS.md
# Created: C:\Users\username\.config\opencode\AGENTS.md ✅

# Windows - absolute path recognized
npx openskills install C:/Users/jayvi/.agent/skills/gh-cli
# Installed from local path ✅
```

## Impact

This change makes the CLI more user-friendly for Windows users without affecting Unix/Linux/macOS behavior. All existing functionality is preserved while adding Windows-specific path format support.